### PR TITLE
Fix file names in test, remove only one file extension when renaming files

### DIFF
--- a/illqclib/main.py
+++ b/illqclib/main.py
@@ -30,11 +30,9 @@ class Trimmomatic(object):
         rev_paired_fp = os.path.join(out_dir, os.path.basename(rev_fp))
 
         fwd_unpaired_fp = os.path.join(
-            out_dir,
-            "%s_unpaired.fastq" % remove_file_ext(remove_file_ext(fwd_fp)))
+            out_dir, "%s_unpaired.fastq" % remove_file_ext(fwd_fp))
         rev_unpaired_fp = os.path.join(
-            out_dir,
-            "%s_unpaired.fastq" % remove_file_ext(remove_file_ext(rev_fp)))
+            out_dir, "%s_unpaired.fastq" % remove_file_ext(rev_fp))
 
         trimlog_fp = os.path.join(out_dir, "trimmomatic.log")
         

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -13,12 +13,12 @@ class TrimmomaticTests(unittest.TestCase):
             "slidingwindow": (4, 15),
             "minlen": 36,
             })
-        observed = app.make_command("a.fastq.gz", "b.fastq.gz", "mydir")
+        observed = app.make_command("a.fastq", "b.fastq", "mydir")
         expected = [
             'java', '-jar', 'trimmomatic-0.30.jar', 'PE', '-phred33',
-            'a.fastq.gz', 'b.fastq.gz',
-            'mydir/a.fastq.gz', 'mydir/b.fastq.gz',
-            'mydir/a_unpaired.fastq.gz', 'mydir/b_unpaired.fastq.gz',
+            'a.fastq', 'b.fastq',
+            'mydir/a.fastq', 'mydir/b.fastq',
+            'mydir/a_unpaired.fastq', 'mydir/b_unpaired.fastq',
             'ILLUMINACLIP:adapters/NexteraPE-PE.fa:2:30:10',
             'LEADING:3', 'TRAILING:3', 'SLIDINGWINDOW:4:15', 'MINLEN:36',
             ]


### PR DESCRIPTION
Test was failing after gzipped input was removed.
